### PR TITLE
Add theme park styling

### DIFF
--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -23,6 +23,11 @@ export const parkOutline = "hsla(136, 41%, 70%, 50%)";
 export const parkLabel = "hsl(136, 71%, 29%)";
 export const parkLabelHalo = "hsl(90, 27%, 94%)";
 
+export const themeParkFill = "hsl(316, 41%, 89%)";
+export const themeParkOutline = "hsla(316, 41%, 70%, 50%)";
+export const themeParkLabel = "hsl(316, 71%, 29%)";
+export const themeParkLabelHalo = "hsl(270, 27%, 94%)";
+
 export const aerialwayLine = "hsl(310, 41%, 59%)";
 export const aerialwayLabel = "hsl(310, 71%, 29%)";
 

--- a/src/layer/index.js
+++ b/src/layer/index.js
@@ -36,6 +36,7 @@ export function build(locales) {
     lyrPark.fill,
     lyrAeroway.fill,
     lyrPark.parkFill,
+    lyrPark.themeParkFill,
 
     lyrBoundary.countyCasing,
     lyrBoundary.regionCasing,
@@ -53,6 +54,7 @@ export function build(locales) {
     lyrPark.outline,
     lyrAeroway.outline,
     lyrPark.parkOutline,
+    lyrPark.themeParkOutline,
 
     lyrBoundary.city,
     lyrBoundary.county,
@@ -218,6 +220,7 @@ export function build(locales) {
 
     lyrPark.label,
     lyrPark.parkLabel,
+    lyrPark.themeParkLabel,
 
     lyrWater.waterLabel,
     lyrWater.waterPointLabel,

--- a/src/layer/park.js
+++ b/src/layer/park.js
@@ -69,9 +69,46 @@ export const parkLabel = {
   "source-layer": "poi",
 };
 
+export const themeParkFill = {
+  ...fill,
+  id: "theme_park_fill",
+  filter: ["==", ["get", "subclass"], "theme_park"],
+  paint: {
+    "fill-color": Color.themeParkFill,
+  },
+  "source-layer": "landcover",
+};
+
+export const themeParkOutline = {
+  ...outline,
+  id: "theme_park_outline",
+  filter: ["==", ["get", "subclass"], "theme_park"],
+  paint: {
+    "line-color": Color.themeParkOutline,
+  },
+  "source-layer": "landcover",
+};
+
+export const themeParkLabel = {
+  ...label,
+  id: "theme_park_label",
+  filter: ["==", ["get", "class"], "theme_park"],
+  paint: {
+    "text-color": Color.themeParkLabel,
+    "text-halo-blur": 1,
+    "text-halo-color": Color.themeParkLabelHalo,
+    "text-halo-width": 1,
+  },
+  "source-layer": "poi",
+};
+
 export const legendEntries = [
   {
     description: "Park",
     layers: [fill.id, outline.id, parkFill.id, parkOutline.id],
+  },
+  {
+    description: "Theme park",
+    layers: [themeParkFill.id, themeParkOutline.id],
   },
 ];


### PR DESCRIPTION
## Summary
- add complementary purple color scheme for theme parks
- render theme park fill, outline, and labels
- include theme parks in layer ordering and legend

## Testing
- `npm test` *(fails: Cannot find module '@americana/maplibre-shield-generator')*

------
https://chatgpt.com/codex/tasks/task_e_68b88a8d7a08832a86b0383ed3a86b95