### PR TITLE
feat: add water park styling

### DIFF
--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -28,6 +28,11 @@ export const themeParkOutline = "hsla(316, 41%, 70%, 50%)";
 export const themeParkLabel = "hsl(316, 71%, 29%)";
 export const themeParkLabelHalo = "hsl(270, 27%, 94%)";
 
+export const waterParkFill = themeParkFill;
+export const waterParkOutline = "hsla(211, 41%, 70%, 50%)";
+export const waterParkLabel = themeParkLabel;
+export const waterParkLabelHalo = themeParkLabelHalo;
+
 export const aerialwayLine = "hsl(310, 41%, 59%)";
 export const aerialwayLabel = "hsl(310, 71%, 29%)";
 

--- a/src/layer/index.js
+++ b/src/layer/index.js
@@ -37,6 +37,7 @@ export function build(locales) {
     lyrAeroway.fill,
     lyrPark.parkFill,
     lyrPark.themeParkFill,
+    lyrPark.waterParkFill,
 
     lyrBoundary.countyCasing,
     lyrBoundary.regionCasing,
@@ -55,6 +56,7 @@ export function build(locales) {
     lyrAeroway.outline,
     lyrPark.parkOutline,
     lyrPark.themeParkOutline,
+    lyrPark.waterParkOutline,
 
     lyrBoundary.city,
     lyrBoundary.county,
@@ -221,6 +223,7 @@ export function build(locales) {
     lyrPark.label,
     lyrPark.parkLabel,
     lyrPark.themeParkLabel,
+    lyrPark.waterParkLabel,
 
     lyrWater.waterLabel,
     lyrWater.waterPointLabel,

--- a/src/layer/park.js
+++ b/src/layer/park.js
@@ -102,6 +102,39 @@ export const themeParkLabel = {
   "source-layer": "poi",
 };
 
+export const waterParkFill = {
+  ...fill,
+  id: "water_park_fill",
+  filter: ["==", ["get", "class"], "water_park"],
+  paint: {
+    "fill-color": Color.waterParkFill,
+  },
+  "source-layer": "landuse",
+};
+
+export const waterParkOutline = {
+  ...outline,
+  id: "water_park_outline",
+  filter: ["==", ["get", "class"], "water_park"],
+  paint: {
+    "line-color": Color.waterParkOutline,
+  },
+  "source-layer": "landuse",
+};
+
+export const waterParkLabel = {
+  ...label,
+  id: "water_park_label",
+  filter: ["==", ["get", "class"], "water_park"],
+  paint: {
+    "text-color": Color.waterParkLabel,
+    "text-halo-blur": 1,
+    "text-halo-color": Color.waterParkLabelHalo,
+    "text-halo-width": 1,
+  },
+  "source-layer": "poi",
+};
+
 export const legendEntries = [
   {
     description: "Park",
@@ -110,5 +143,9 @@ export const legendEntries = [
   {
     description: "Theme park",
     layers: [themeParkFill.id, themeParkOutline.id],
+  },
+  {
+    description: "Water park",
+    layers: [waterParkFill.id, waterParkOutline.id],
   },
 ];


### PR DESCRIPTION
## Summary
- style water parks like theme parks
- color water park outlines blue
- include water parks in legend and layer index

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a07c2d5c832aac0bb9e67370d2d5