### PR TITLE
Add attraction landuse styling

### DIFF
--- a/src/constants/color.js
+++ b/src/constants/color.js
@@ -23,15 +23,10 @@ export const parkOutline = "hsla(136, 41%, 70%, 50%)";
 export const parkLabel = "hsl(136, 71%, 29%)";
 export const parkLabelHalo = "hsl(90, 27%, 94%)";
 
-export const themeParkFill = "hsl(24, 50%, 88%)";
-export const themeParkOutline = "hsla(24, 50%, 27%, 50%)";
-export const themeParkLabel = "hsl(24, 50%, 27%)";
-export const themeParkLabelHalo = "hsl(24, 50%, 95%)";
-
-export const waterParkFill = themeParkFill;
-export const waterParkOutline = themeParkOutline;
-export const waterParkLabel = themeParkLabel;
-export const waterParkLabelHalo = themeParkLabelHalo;
+export const attractionFill = "hsl(24, 50%, 88%)";
+export const attractionOutline = "hsla(24, 50%, 27%, 50%)";
+export const attractionLabel = "hsl(24, 50%, 27%)";
+export const attractionLabelHalo = "hsl(24, 50%, 95%)";
 
 export const aerialwayLine = "hsl(310, 41%, 59%)";
 export const aerialwayLabel = "hsl(310, 71%, 29%)";

--- a/src/layer/index.js
+++ b/src/layer/index.js
@@ -36,8 +36,7 @@ export function build(locales) {
     lyrPark.fill,
     lyrAeroway.fill,
     lyrPark.parkFill,
-    lyrPark.themeParkFill,
-    lyrPark.waterParkFill,
+    lyrPark.attractionFill,
 
     lyrBoundary.countyCasing,
     lyrBoundary.regionCasing,
@@ -55,8 +54,7 @@ export function build(locales) {
     lyrPark.outline,
     lyrAeroway.outline,
     lyrPark.parkOutline,
-    lyrPark.themeParkOutline,
-    lyrPark.waterParkOutline,
+    lyrPark.attractionOutline,
 
     lyrBoundary.city,
     lyrBoundary.county,
@@ -222,8 +220,7 @@ export function build(locales) {
 
     lyrPark.label,
     lyrPark.parkLabel,
-    lyrPark.themeParkLabel,
-    lyrPark.waterParkLabel,
+    lyrPark.attractionLabel,
 
     lyrWater.waterLabel,
     lyrWater.waterPointLabel,

--- a/src/layer/park.js
+++ b/src/layer/park.js
@@ -69,67 +69,46 @@ export const parkLabel = {
   "source-layer": "poi",
 };
 
-export const themeParkFill = {
+export const attractionFill = {
   ...fill,
-  id: "theme_park_fill",
-  filter: ["==", ["get", "class"], "theme_park"],
+  id: "attraction_fill",
+  filter: [
+    "in",
+    ["get", "class"],
+    ["literal", ["theme_park", "water_park", "zoo"]],
+  ],
   paint: {
-    "fill-color": Color.themeParkFill,
+    "fill-color": Color.attractionFill,
   },
   "source-layer": "landuse",
 };
 
-export const themeParkOutline = {
+export const attractionOutline = {
   ...outline,
-  id: "theme_park_outline",
-  filter: ["==", ["get", "class"], "theme_park"],
+  id: "attraction_outline",
+  filter: [
+    "in",
+    ["get", "class"],
+    ["literal", ["theme_park", "water_park", "zoo"]],
+  ],
   paint: {
-    "line-color": Color.themeParkOutline,
+    "line-color": Color.attractionOutline,
   },
   "source-layer": "landuse",
 };
 
-export const themeParkLabel = {
+export const attractionLabel = {
   ...label,
-  id: "theme_park_label",
-  filter: ["==", ["get", "class"], "theme_park"],
+  id: "attraction_label",
+  filter: [
+    "in",
+    ["get", "class"],
+    ["literal", ["theme_park", "water_park", "zoo"]],
+  ],
   paint: {
-    "text-color": Color.themeParkLabel,
+    "text-color": Color.attractionLabel,
     "text-halo-blur": 1,
-    "text-halo-color": Color.themeParkLabelHalo,
-    "text-halo-width": 1,
-  },
-  "source-layer": "poi",
-};
-
-export const waterParkFill = {
-  ...fill,
-  id: "water_park_fill",
-  filter: ["==", ["get", "class"], "water_park"],
-  paint: {
-    "fill-color": Color.waterParkFill,
-  },
-  "source-layer": "landuse",
-};
-
-export const waterParkOutline = {
-  ...outline,
-  id: "water_park_outline",
-  filter: ["==", ["get", "class"], "water_park"],
-  paint: {
-    "line-color": Color.waterParkOutline,
-  },
-  "source-layer": "landuse",
-};
-
-export const waterParkLabel = {
-  ...label,
-  id: "water_park_label",
-  filter: ["==", ["get", "class"], "water_park"],
-  paint: {
-    "text-color": Color.waterParkLabel,
-    "text-halo-blur": 1,
-    "text-halo-color": Color.waterParkLabelHalo,
+    "text-halo-color": Color.attractionLabelHalo,
     "text-halo-width": 1,
   },
   "source-layer": "poi",
@@ -141,11 +120,7 @@ export const legendEntries = [
     layers: [fill.id, outline.id, parkFill.id, parkOutline.id],
   },
   {
-    description: "Theme park",
-    layers: [themeParkFill.id, themeParkOutline.id],
-  },
-  {
-    description: "Water park",
-    layers: [waterParkFill.id, waterParkOutline.id],
+    description: "Attraction",
+    layers: [attractionFill.id, attractionOutline.id],
   },
 ];


### PR DESCRIPTION
## Summary
- consolidate theme and water park layers into a single attraction style
- support zoos as landuse attractions and label them uniformly

## Testing
- `npm test`
- `npm run build:code`


------
https://chatgpt.com/codex/tasks/task_e_68b99d2daf5c832a9207366cb333a7f2